### PR TITLE
Only package essential files in gem release

### DIFF
--- a/jsoneditor-rails.gemspec
+++ b/jsoneditor-rails.gemspec
@@ -11,11 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/jackpocket/jsoneditor-rails"
   spec.license = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = Dir["README.md", "LICENSE*", "lib/**/*.rb", "vendor/**/{.*,*}"]
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "railties", ">= 3.0"


### PR DESCRIPTION
This updates the gemspec files listing to only include the essential files for the gem release.